### PR TITLE
Add CAS authentication against an upstream CAS server

### DIFF
--- a/docs/source/configuration.md
+++ b/docs/source/configuration.md
@@ -118,8 +118,10 @@ Currently available options are:
 
 - `django` - the internal user model authentication backend of Django
 - `ldap` - a generic LDAP-based authentication
+- `cas` - redirect all auth to an upstream CAS server
 
-If you combine different backends, they will be checked in order of listing. So if
+While `cas` will overrule other authentication backends, generally you can combine
+different backends, so they will be checked in order of listing. So if
 you for example use:
 
 ```
@@ -165,3 +167,30 @@ Now depending on your setup you can use three different ways to query your users
    list of distinguished names. E.g.:
    `ou=unit1,ou=users,dc=example,dc=com;ou=unit2,ou=users,dc=example,dc=com`
    This will only work, if `AUTH_LDAP_USER_SEARCH_BASE` is not set.
+
+#### CAS
+
+```{note}
+This authentication backend will overrule all other backends you might have configured.
+All login and logout routes will be redirected to the upstream CAS server.
+```
+
+If `cas` is used in the `AUTHENTICATION_BACKENDS`, you also have to set the following:
+
+- `CAS_SERVER` has to point to an upstream CAS server, which all login and logout
+  attempts will be redirected to.
+
+All other `CAS_` settings are optional (for details see the
+[django-cas-ng config docs](https://djangocas.dev/docs/4.0/configuration.html)):
+
+- `CAS_VERSION` : specifies the version of the CAS protocol and defaults to `3`
+- `CAS_REDIRECT_URL` : specifies the redirect to happen after successful login and
+  defaults to `/`. This only affects logins directly on baseauth. Logins coming
+  from one of the apps already have their redirect URL set.
+- `CAS_VERIFY_SSL_CERTIFICATE` : defaults to `True` and should not be changed in any
+  production context. For local testing you can disable the SSL certificate check
+  (e.g. if case of a self-signed certificate).
+- `CAS_RENAME_ATTRIBUTES` : a dictionary used to rename the (key of the) attributes
+  that the upstream CAS server may return. Is empty by default, so no renaming happens.
+  For example, if `CAS_RENAME_ATTRIBUTES=ln=last_name,fn=first_name` the `ln` attribute
+  returned by the cas server will be renamed as `last_name` and `fn` to `first_name`.

--- a/src/baseauth/env-skel
+++ b/src/baseauth/env-skel
@@ -74,3 +74,11 @@ SITE_URL=https://url/
 # AUTH_LDAP_USER_SEARCH_BASE=
 # AUTH_LDAP_USER_SEARCH_BASE_LIST=
 # AUTH_LDAP_USER_SEARCH_USER_TEMPLATE=
+
+## CAS authentication (only needed if cas occurs in AUTHENTICATION_BACKENDS above)
+## See the configuration section in the docs for details.
+# CAS_SERVER=
+# CAS_VERSION=3
+# CAS_REDIRECT_URL=/
+# CAS_VERIFY_SSL_CERTIFICATE=True
+# CAS_RENAME_ATTRIBUTES=

--- a/src/baseauth/settings.py
+++ b/src/baseauth/settings.py
@@ -131,8 +131,9 @@ for backend in AUTH_BACKENDS_TO_USE:
         CAS_VERSION = env.str('CAS_VERSION', default='3')
         CAS_APPLY_ATTRIBUTES_TO_USER = True
         CAS_REDIRECT_URL = env.str('CAS_REDIRECT_URL', default=FORCE_SCRIPT_NAME or '/')
-        CAS_CHECK_NEXT = env.bool('CAS_CHECK_NEXT', default=True)
-        CAS_VERIFY_CERTIFICATE = env.bool('CAS_VERIFY_CERTIFICATE', default=True)
+        CAS_VERIFY_SSL_CERTIFICATE = env.bool(
+            'CAS_VERIFY_SSL_CERTIFICATE', default=True
+        )
         CAS_RENAME_ATTRIBUTES = env.dict('CAS_RENAME_ATTRIBUTES', default={})
 
     # A generically configurable LDAP authentication backend

--- a/src/baseauth/settings.py
+++ b/src/baseauth/settings.py
@@ -118,6 +118,23 @@ for backend in AUTH_BACKENDS_TO_USE:
     if backend == 'django':
         AUTHENTICATION_BACKENDS.append('django.contrib.auth.backends.ModelBackend')
 
+    if backend == 'cas':
+        INSTALLED_APPS.append('django_cas_ng')
+        AUTHENTICATION_BACKENDS.append('django_cas_ng.backends.CASBackend')
+
+        CAS_SERVER_URL = env.str('CAS_SERVER', default=f'{SITE_URL}cas/')
+        CAS_LOGIN_MSG = None
+        CAS_LOGGED_MSG = None
+        CAS_RENEW = False
+        CAS_LOGOUT_COMPLETELY = True
+        CAS_RETRY_LOGIN = True
+        CAS_VERSION = env.str('CAS_VERSION', default='3')
+        CAS_APPLY_ATTRIBUTES_TO_USER = True
+        CAS_REDIRECT_URL = env.str('CAS_REDIRECT_URL', default=FORCE_SCRIPT_NAME or '/')
+        CAS_CHECK_NEXT = env.bool('CAS_CHECK_NEXT', default=True)
+        CAS_VERIFY_CERTIFICATE = env.bool('CAS_VERIFY_CERTIFICATE', default=True)
+        CAS_RENAME_ATTRIBUTES = env.dict('CAS_RENAME_ATTRIBUTES', default={})
+
     # A generically configurable LDAP authentication backend
     # See https://django-auth-ldap.readthedocs.io/en/latest/authentication.html for details
     if backend == 'ldap':
@@ -219,6 +236,8 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'axes.middleware.AxesMiddleware',
 ]
+if 'cas' in AUTH_BACKENDS_TO_USE:
+    MIDDLEWARE.append('django_cas_ng.middleware.CASMiddleware')
 
 AXES_LOCKOUT_URL = reverse_lazy('locked_out')
 AXES_VERBOSE = DEBUG

--- a/src/baseauth/urls.py
+++ b/src/baseauth/urls.py
@@ -13,7 +13,16 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from mama_cas.views import LoginView
+from mama_cas.views import (
+    LoginView,
+    LogoutView,
+    ProxyValidateView,
+    ProxyView,
+    SamlValidateView,
+    ServiceValidateView,
+    ValidateView,
+    WarnView,
+)
 
 from django.conf import settings
 from django.contrib import admin
@@ -30,9 +39,29 @@ urlpatterns = [
     ),
     # admin
     path('admin/', admin.site.urls),
-    # views
+    # cas views
     path('login/', LoginView.as_view(), name='cas_login'),
-    path('', include('mama_cas.urls')),
+    path('logout/', LogoutView.as_view(), name='cas_logout'),
+    path('validate/', ValidateView.as_view(), name='cas_validate'),
+    path(
+        'serviceValidate/',
+        ServiceValidateView.as_view(),
+        name='cas_service_validate',
+    ),
+    path('proxyValidate/', ProxyValidateView.as_view(), name='cas_proxy_validate'),
+    path('proxy/', ProxyView.as_view(), name='cas_proxy'),
+    path(
+        'p3/serviceValidate/',
+        ServiceValidateView.as_view(),
+        name='cas_p3_service_validate',
+    ),
+    path(
+        'p3/proxyValidate/',
+        ProxyValidateView.as_view(),
+        name='cas_p3_proxy_validate',
+    ),
+    path('warn/', WarnView.as_view(), name='cas_warn'),
+    path('samlValidate/', SamlValidateView.as_view(), name='cas_saml_validate'),
     path('captcha/', include('captcha.urls')),
     path('locked/', locked_out, name='locked_out'),
     # i18n

--- a/src/baseauth/urls.py
+++ b/src/baseauth/urls.py
@@ -78,11 +78,28 @@ if 'cas' not in settings.AUTH_BACKENDS_TO_USE:
 else:
     import django_cas_ng.views
 
+    class LogoutRedirectView(RedirectView):
+        """A special RedirectView transforming the service to a next
+        parameter."""
+
+        def get_redirect_url(self, *args, **kwargs):
+            """Provide the redirect url with an optional service parameter
+            rewritten to next."""
+            if self.url:
+                url = self.url % kwargs
+            else:
+                return None
+
+            service_url = self.request.GET.get('service')
+            if service_url:
+                url = f'{url}?&next={service_url}'
+            return url
+
     urlpatterns += [
         path('login/', login_required(LoginView.as_view()), name='cas_login'),
         path(
             'logout/',
-            RedirectView.as_view(url=reverse_lazy('cas_ng_logout')),
+            LogoutRedirectView.as_view(url=reverse_lazy('cas_ng_logout')),
             name='cas_logout',
         ),
         path(

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -31,6 +31,7 @@ django==4.2.7
     #   -r src/requirements.in
     #   django-auth-ldap
     #   django-axes
+    #   django-cas-ng
     #   django-cors-headers
     #   django-debug-toolbar
     #   django-ranged-response
@@ -42,6 +43,8 @@ django-axes[ipware]==6.1.1
     # via
     #   -r src/requirements.in
     #   django-axes
+django-cas-ng==5.0.1
+    # via -r src/requirements.in
 django-cors-headers==4.3.0
     # via -r src/requirements.in
 django-debug-toolbar==4.2.0
@@ -70,6 +73,8 @@ identify==2.5.31
     # via pre-commit
 idna==3.4
     # via requests
+lxml==4.9.3
+    # via python-cas
 nodeenv==1.8.0
     # via pre-commit
 packaging==23.2
@@ -104,6 +109,8 @@ pyasn1-modules==0.3.0
     # via python-ldap
 pyproject-hooks==1.0.0
     # via build
+python-cas==1.6.0
+    # via django-cas-ng
 python-ldap==3.4.3
     # via django-auth-ldap
 pyyaml==6.0.1
@@ -116,9 +123,12 @@ requests==2.31.0
     # via
     #   -r src/requirements.in
     #   django-mama-cas
+    #   python-cas
     #   requests-futures
 requests-futures==1.0.1
     # via -r src/requirements.in
+six==1.16.0
+    # via python-cas
 sqlparse==0.4.4
     # via
     #   django

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -6,6 +6,7 @@ concurrent-log-handler==0.9.24
 django==4.2.7
 django-auth-ldap==4.6.0
 django-axes[ipware]==6.1.1
+django-cas-ng==5.0.1
 django-cors-headers==4.3.0
 django-debug-toolbar==4.2.0
 django-environ==0.11.2

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -27,6 +27,7 @@ django==4.2.7
     #   -r src/requirements.in
     #   django-auth-ldap
     #   django-axes
+    #   django-cas-ng
     #   django-cors-headers
     #   django-debug-toolbar
     #   django-ranged-response
@@ -38,6 +39,8 @@ django-axes[ipware]==6.1.1
     # via
     #   -r src/requirements.in
     #   django-axes
+django-cas-ng==5.0.1
+    # via -r src/requirements.in
 django-cors-headers==4.3.0
     # via -r src/requirements.in
 django-debug-toolbar==4.2.0
@@ -62,6 +65,8 @@ gunicorn==21.2.0
     # via -r src/requirements.in
 idna==3.4
     # via requests
+lxml==4.9.3
+    # via python-cas
 packaging==23.2
     # via
     #   build
@@ -90,6 +95,8 @@ pyasn1-modules==0.3.0
     # via python-ldap
 pyproject-hooks==1.0.0
     # via build
+python-cas==1.6.0
+    # via django-cas-ng
 python-ldap==3.4.3
     # via django-auth-ldap
 rainbow-saddle==0.4.0
@@ -100,9 +107,12 @@ requests==2.31.0
     # via
     #   -r src/requirements.in
     #   django-mama-cas
+    #   python-cas
     #   requests-futures
 requests-futures==1.0.1
     # via -r src/requirements.in
+six==1.16.0
+    # via python-cas
 sqlparse==0.4.4
     # via
     #   django


### PR DESCRIPTION
This adds another configurable authentication "backend" (rather a redirector) that redirects all login and logout attempts to an upstream CAS server.